### PR TITLE
Added <threadsafe>true</threadsafe> to all java apps

### DIFF
--- a/java/bookjps/war/WEB-INF/appengine-web.xml
+++ b/java/bookjps/war/WEB-INF/appengine-web.xml
@@ -2,4 +2,5 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <application>bookjpa</application>
   <version>exampletest</version>
+  <threadsafe>true</threadsafe>
 </appengine-web-app>

--- a/java/booklowlevel/war/WEB-INF/appengine-web.xml
+++ b/java/booklowlevel/war/WEB-INF/appengine-web.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <application>bookLowLevel</application>
+  <threadsafe>true</threadsafe>
   <version>exampletest</version>
 </appengine-web-app>

--- a/java/clock/war/WEB-INF/appengine-web.xml
+++ b/java/clock/war/WEB-INF/appengine-web.xml
@@ -2,7 +2,7 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 	<application>aebookclock</application>
 	<version>exampletest</version>
-	
+        <threadsafe>true</threadsafe>
 	<!-- Configure java.util.logging -->
 	<system-properties>
 		<property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>

--- a/java/entities/war/WEB-INF/appengine-web.xml
+++ b/java/entities/war/WEB-INF/appengine-web.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <application>entities</application>
+  <threadsafe>true</threadsafe>
   <version>exampletest</version>
 </appengine-web-app>

--- a/java/guestbook-memcache/war/WEB-INF/appengine-web.xml
+++ b/java/guestbook-memcache/war/WEB-INF/appengine-web.xml
@@ -2,7 +2,7 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 	<application>guestbookmemcached</application>
 	<version>1</version>
-	
+        <threadsafe>true</threadsafe>
 	<!-- Configure java.util.logging -->
 	<system-properties>
 		<property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>

--- a/java/javaBlobstoreApp/war/WEB-INF/appengine-web.xml
+++ b/java/javaBlobstoreApp/war/WEB-INF/appengine-web.xml
@@ -2,6 +2,7 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 	<application>simpleBlobstore</application>
 	<version>1</version>
+        <threadsafe>true</threadsafe>
 	
 	<!-- Configure java.util.logging -->
 	<system-properties>

--- a/java/javabook/war/WEB-INF/appengine-web.xml
+++ b/java/javabook/war/WEB-INF/appengine-web.xml
@@ -2,7 +2,7 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 	<application>javabook</application>
 	<version>1</version>
-	
+        <threadsafe>true</threadsafe>
 	<!-- Configure java.util.logging -->
 	<system-properties>
 		<property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>

--- a/java/queries/war/WEB-INF/appengine-web.xml
+++ b/java/queries/war/WEB-INF/appengine-web.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <application>aebookquery</application>
+  <threadsafe>true</threadsafe>
   <version>exampletest</version>
 </appengine-web-app>

--- a/java/staticfiles/war/WEB-INF/appengine-web.xml
+++ b/java/staticfiles/war/WEB-INF/appengine-web.xml
@@ -2,6 +2,7 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <application>ae-book</application>
   <version>exampletest</version>
+  <threadsafe>true</threadsafe>
 
   <static-files>
     <include path="static/**" />

--- a/java/transaction/war/WEB-INF/appengine-web.xml
+++ b/java/transaction/war/WEB-INF/appengine-web.xml
@@ -2,7 +2,7 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 	<application>transaction</application>
 	<version>exampletest</version>
-	
+        <threadsafe>true</threadsafe>
 	<!-- Configure java.util.logging -->
 	<system-properties>
 		<property name="java.util.logging.config.file" value="WEB-INF/logging.properties"/>

--- a/java/types/war/WEB-INF/appengine-web.xml
+++ b/java/types/war/WEB-INF/appengine-web.xml
@@ -2,4 +2,5 @@
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
   <application>types</application>
   <version>exampletest</version>
+  <threadsafe>true</threadsafe>
 </appengine-web-app>


### PR DESCRIPTION
With our new Java AppServer, the "threadsafe" parameter is now a required parameter, which our apps did not previously have (and thus they were broken).
